### PR TITLE
copy liblmdb.so library to lib

### DIFF
--- a/script/build_lmdb.sh
+++ b/script/build_lmdb.sh
@@ -35,6 +35,7 @@ git pull
     
     cp *.h ../../../../include
     cp *.a ../../../../lib
+    cp *.so ../../../../lib
     cd ../../../../
  #   cp patches/libtool/liblmdb.la lib/liblmdb.la
  #   echo "libdir='$PREFIX/lib'" >> lib/liblmdb.la


### PR DESCRIPTION
### Problem: 
Libmodsec cannot find the LMDB library in the `lib` folder when running `build_ols.sh`.

```bash
configure: LMDB headers found at: /usr/local/src/third-party/include
configure: error: LMDB was explicitly referenced but it was not found
make: *** No targets specified and no makefile found.  Stop.
cp: cannot stat 'src/.libs/libmodsecurity.a': No such file or directory
```

### Solution:
This PR resolves the issue by copying the `liblmdb.so` library file into the `lib` folder.